### PR TITLE
Add check if response keys available

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -114,7 +114,10 @@ namespace arangodb { namespace fuerte { namespace php {
         auto response = new Response(*result);
 
         bool failure = false;
-        if(response->getFuerteResponse()->slices().front().isObject()) {
+
+        if (response->getFuerteResponse()->slices().front().isObject()
+            && response->getFuerteResponse()->slices().front().hasKey("error")
+        ) {
             failure = response->getFuerteResponse()->slices().front().get("error").getBool();
         }
 
@@ -122,7 +125,9 @@ namespace arangodb { namespace fuerte { namespace php {
         if((!(statusCode >= 200 && statusCode <= 299)) || failure) {
             std::string errorMessage = "Response contains an error";
 
-            if(response->getFuerteResponse()->slices().front().isObject()) {
+            if(response->getFuerteResponse()->slices().front().isObject()
+               && response->getFuerteResponse()->slices().front().hasKey("errorMessage")
+            ) {
                 errorMessage = response->getFuerteResponse()->slices().front().get("errorMessage").copyString();
             }
 

--- a/tests/CursorTest.php
+++ b/tests/CursorTest.php
@@ -247,4 +247,23 @@ class CursorTest extends TestCase
         $this->assertCount(100, $dataSet2);
         $this->assertSame($dataSet1, \array_slice($dataSet2, 0, 50));
     }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_if_collection_not_found()
+    {
+        $collection = 'event_streams';
+        $this->connection = TestUtil::getConnection();
+
+        $this->expectException(\ArangoDb\RequestFailedException::class);
+
+        $cursor = $this->connection->query(Vpack::fromArray([
+            'query' => 'FOR c IN @@collection RETURN c',
+            'bindVars' => ['@collection' => $collection]
+        ]));
+
+        $cursor->rewind();
+        $iterations = 0;
+    }
 }


### PR DESCRIPTION
The problem was, that response is also possible

```
{"_id":"event_streams/1","_key":"1","_rev":"_WCBVpJC---"}
```